### PR TITLE
Add GHE socket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,23 @@ both their username and real name in the autocomplete item label.
 You can search by real name by separating the names with underscores. For
 example, if you type `@chris_birchall` you will also get you an autocomplete
 list containing my username `@cb372`.
+
+## Github Enterprise support
+
+If you have an internal GitHub enterprise installation at work, you can configure it like so:
+
+```json
+{
+  "coc.githubUsers.graphqlApiUrl": "http://your.internal.github.company.com/api/graphql",
+  "coc.githubUsers.unixSocket": "/optional/path/to/unix.sock"
+}
+```
+
+The `unixSocket` is optional, but useful if your company proxies all internal traffic through a local socket.
+
+If you prefer ENV variables, you can configure:
+
+* `COC_GITHUB_USERS_GRAPHQL_API_URL`
+* `COC_GITHUB_USERS_UNIX_SOCKET`
+
+in your shell environment instead.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,18 @@ export function activate(context: ExtensionContext): Promise<void> {
   const accessToken = config.get<string>('githubAccessToken', process.env.COC_GITHUB_USERS_TOKEN)
   if (!accessToken) return
 
+  const graphqlApiUrl = config.get<string>('graphqlApiUrl', process.env.COC_GITHUB_USERS_GRAPHQL_API_URL)
+  const unixSocket = config.get<string>('unixSocket', process.env.COC_GITHUB_USERS_UNIX_SOCKET)
+
   const { subscriptions } = context
 
-  const ghUsersCompletionProvider = new GitHubUsersCompletionProvider(accessToken)
+  const ghUsersCompletionProvider = new GitHubUsersCompletionProvider(
+    accessToken,
+    {
+      graphqlApiUrl,
+      unixSocket
+    }
+  )
 
   subscriptions.push(
     languages.registerCompletionItemProvider(

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,9 +278,9 @@ await-semaphore@^0.1.3:
   integrity sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==
 
 axios@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.1.tgz#8a6a04eed23dfe72747e1dd43c604b8f1677b5aa"
-  integrity sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
 


### PR DESCRIPTION
This adds support for UNIX sockets to this plugin for anyone that wants to hook into their company's internal Github Enterprise install.

Adds new config:

* `coc.githubUsers.graphqlApiUrl: "http://your.corp.github.company.com/api/graphql"` - your internal path to your GHE url
* `coc.githubUsers.unixSocket: "/path/to/your/unix.sock"` - the UNIX socket used to securely proxy requests

These config vars are mirrored in `COC_GITHUB_USERS_GRAPHQL_API_URL` and `COC_GITHUB_USERS_UNIX_SOCKET`.